### PR TITLE
Updated package name in activity_main.xml

### DIFF
--- a/samples/augmented_image_java/app/src/main/res/layout/activity_main.xml
+++ b/samples/augmented_image_java/app/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.google.ar.core.apps.augmentedimage.AugmentedImageActivity">
+    tools:context="com.google.ar.core.examples.java.augmentedimage.AugmentedImageActivity">
 
   <android.opengl.GLSurfaceView
       android:id="@+id/surfaceview"


### PR DESCRIPTION
samples > augmented_image_java>src>res>layout>activity_main.xml
Error - Unresolved package name 
Fixing this by replacing this line - 
`tools:context = "com.google.ar.core.apps.augmentedimage.AugmentedImageActivity"`
by
`tools:context = "com.google.ar.core.examples.java.augmentedimage.AugmentedImageActivity"`