### PR TITLE
fix wrong calculation of the total bitmap size in  util.cc

### DIFF
--- a/samples/augmented_image_c/app/src/main/cpp/util.cc
+++ b/samples/augmented_image_c/app/src/main/cpp/util.cc
@@ -256,7 +256,7 @@ bool LoadImageFromAssetManager(const std::string& path, int* out_width,
         ANDROID_BITMAP_RESULT_SUCCESS);
 
   // Copy jvm_buffer_address to pixel_buffer_address
-  int32_t total_size_in_byte = bitmap_info.stride * bitmap_info.width;
+  int32_t total_size_in_byte = bitmap_info.stride * bitmap_info.height;
   *out_pixel_buffer = new uint8_t[total_size_in_byte];
   memcpy(*out_pixel_buffer, jvm_buffer, total_size_in_byte);
 


### PR DESCRIPTION
The total size in bytes is calculated by multiplying the stride by the height, not the width. This is because the stride represents the number of bytes in a row of pixels, and there are height number of rows in the bitmap. So to calculate the total size of the buffer, you need to multiply the stride by the height, not the width.