### PR TITLE
call ArImage_release after texture is updated

### DIFF
--- a/samples/hello_ar_c/app/src/main/cpp/texture.cc
+++ b/samples/hello_ar_c/app/src/main/cpp/texture.cc
@@ -74,12 +74,14 @@ void Texture::UpdateWithDepthImageOnGlThread(const ArSession& session,
   ArImage_getHeight(&session, depth_image, &image_height);
   ArImage_getPlanePixelStride(&session, depth_image, 0, &image_pixel_stride);
   ArImage_getPlaneRowStride(&session, depth_image, 0, &image_row_stride);
-  ArImage_release(depth_image);
+
   glBindTexture(GL_TEXTURE_2D, texture_id_);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RG8, image_width, image_height, 0, GL_RG,
                GL_UNSIGNED_BYTE, depth_data);
   width_ = image_width;
   height_ = image_height;
+  
+  ArImage_release(depth_image);
 }
 
 }  // namespace hello_ar


### PR DESCRIPTION
move ArImage_release to the end of the function , after image is uploaded to the GPU to prevent trash values in the depth texture.