### PR TITLE
Incorrect explanation of QUAD_COORDS

### DIFF
--- a/samples/augmented_faces_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/augmented_faces_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/augmented_image_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/augmented_image_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/cloud_anchor_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/cloud_anchor_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/computervision_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/computervision_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/persistent_cloud_anchor_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/persistent_cloud_anchor_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/raw_depth_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/raw_depth_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/recording_playback_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/recording_playback_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {

--- a/samples/shared_camera_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
+++ b/samples/shared_camera_java/app/src/main/java/com/google/ar/core/examples/java/common/rendering/BackgroundRenderer.java
@@ -310,7 +310,7 @@ public class BackgroundRenderer {
    * (-1, -1) ------ (1, -1)
    * Ensure triangles are front-facing, to support glCullFace().
    * This quad will be drawn using GL_TRIANGLE_STRIP which draws two
-   * triangles: v0->v1->v2, then v2->v1->v3.
+   * triangles: v0->v1->v2, then v1->v2->v3.
    */
   private static final float[] QUAD_COORDS =
       new float[] {


### PR DESCRIPTION
If a quad is drawn using GL_TRIANGLE_STRIP, the triangles' drawing order should be v0 → v1 → v2, then v1 → v2 → v3 (not v2 → v1 → v3).